### PR TITLE
feat: Support handle extra syscalls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ dist
 c/tests/runtest
 *.debug
 crates/layer/Cargo.lock
+crates/layer/target/

--- a/crates/layer/Cargo.toml
+++ b/crates/layer/Cargo.toml
@@ -10,11 +10,11 @@ edition = "2018"
 blake2b-rs = { version = "0.1" }
 bytes = "0.5.4"
 ckb-types = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.31.0-pre1" }
+ckb-script = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.31.0-pre1" }
 ckb-vm = { version = "0.19.1", features = ["asm"] }
 derive_more = "0.99.2"
 replace_with = "0.1.5"
 sparse-merkle-tree = { git = "https://github.com/jjyr/sparse-merkle-tree", rev = "0e313cf" }
 
 [dev-dependencies]
-ckb-script = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.31.0-pre1" }
 hex = "0.4.2"

--- a/crates/layer/Cargo.toml
+++ b/crates/layer/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2018"
 [dependencies]
 blake2b-rs = { version = "0.1" }
 bytes = "0.5.4"
-ckb-types = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.31.0-pre1" }
-ckb-script = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.31.0-pre1" }
+ckb-types = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.35.0-rc1" }
+ckb-script = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.35.0-rc1" }
 ckb-vm = { version = "0.19.1", features = ["asm"] }
 derive_more = "0.99.2"
 replace_with = "0.1.5"

--- a/crates/layer/Cargo.toml
+++ b/crates/layer/Cargo.toml
@@ -14,7 +14,7 @@ ckb-script = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.31.0-pre1
 ckb-vm = { version = "0.19.1", features = ["asm"] }
 derive_more = "0.99.2"
 replace_with = "0.1.5"
-sparse-merkle-tree = { git = "https://github.com/jjyr/sparse-merkle-tree", rev = "0e313cf" }
+sparse-merkle-tree = "0.3"
 
 [dev-dependencies]
 hex = "0.4.2"

--- a/crates/layer/src/ckb.rs
+++ b/crates/layer/src/ckb.rs
@@ -155,12 +155,7 @@ impl<S: Store<H256> + ClearStore> CkbSimpleAccount<S> {
         let data = BytesOpt::new_builder()
             .set(Some(proof.serialize(program)?.pack()))
             .build();
-        let mut witness_builder = WitnessArgs::new_builder();
-        if self.last_cell.is_none() {
-            witness_builder = witness_builder.output_type(data);
-        } else {
-            witness_builder = witness_builder.input_type(data);
-        }
+        let witness_builder = WitnessArgs::new_builder().output_type(data);
         let mut output_builder = CellOutput::new_builder()
             .type_(
                 ScriptOpt::new_builder()

--- a/crates/layer/src/ckb.rs
+++ b/crates/layer/src/ckb.rs
@@ -155,7 +155,12 @@ impl<S: Store<H256> + ClearStore> CkbSimpleAccount<S> {
         let data = BytesOpt::new_builder()
             .set(Some(proof.serialize(program)?.pack()))
             .build();
-        let witness_builder = WitnessArgs::new_builder().output_type(data);
+        let mut witness_builder = WitnessArgs::new_builder();
+        if self.last_cell.is_none() {
+            witness_builder = witness_builder.output_type(data);
+        } else {
+            witness_builder = witness_builder.input_type(data);
+        }
         let mut output_builder = CellOutput::new_builder()
             .type_(
                 ScriptOpt::new_builder()

--- a/crates/layer/src/lib.rs
+++ b/crates/layer/src/lib.rs
@@ -99,11 +99,11 @@ pub fn run_with_context<S: Store<H256>, C: RunContext<Box<AsmCoreMachine>>>(
     {
         let core_machine = Box::<AsmCoreMachine>::default();
         let machine_builder = DefaultMachineBuilder::new(core_machine)
+            .syscall(Box::new(ExtraSyscalls::new(context)))
             .syscall(Box::new(TreeSyscalls {
                 tree,
                 result: &mut result,
-            }))
-            .syscall(Box::new(ExtraSyscalls::new(context)));
+            }));
         let mut machine = AsmMachine::new(machine_builder.build(), None);
         let program_name = Bytes::from_static(b"generator");
         let program_length_bytes = (program.len() as u32).to_le_bytes()[..].to_vec();

--- a/crates/layer/src/smt.rs
+++ b/crates/layer/src/smt.rs
@@ -105,12 +105,12 @@ impl<'a, S: Store<H256>> Store<H256> for WrappedStore<'a, S> {
         Ok(())
     }
     fn remove_branch(&mut self, node: &H256) -> Result<(), SMTError> {
-        self.deleted_branches.insert(node.clone());
+        self.deleted_branches.insert(*node);
         self.branches_map.remove(node);
         Ok(())
     }
     fn remove_leaf(&mut self, leaf_hash: &H256) -> Result<(), SMTError> {
-        self.deleted_leaves.insert(leaf_hash.clone());
+        self.deleted_leaves.insert(*leaf_hash);
         self.leaves_map.remove(leaf_hash);
         Ok(())
     }

--- a/crates/layer/src/vm.rs
+++ b/crates/layer/src/vm.rs
@@ -8,12 +8,12 @@ use sparse_merkle_tree::{
     SparseMerkleTree, H256,
 };
 
-pub(crate) struct TreeSyscalls<'a, H: Hasher + Default, S: Store<H256>> {
+pub(crate) struct VmSyscalls<'a, H: Hasher + Default, S: Store<H256>> {
     pub(crate) tree: &'a SparseMerkleTree<H, H256, S>,
     pub(crate) result: &'a mut RunResult,
 }
 
-fn load_data<Mac: SupportMachine>(machine: &mut Mac, address: u64) -> Result<H256, VMError> {
+fn load_h256<Mac: SupportMachine>(machine: &mut Mac, address: u64) -> Result<H256, VMError> {
     let mut data = [0u8; 32];
     for (i, c) in data.iter_mut().enumerate() {
         *c = machine
@@ -22,6 +22,21 @@ fn load_data<Mac: SupportMachine>(machine: &mut Mac, address: u64) -> Result<H25
             .to_u8();
     }
     Ok(H256::from(data))
+}
+
+fn load_data<Mac: SupportMachine>(
+    machine: &mut Mac,
+    address: u64,
+    length: u32,
+) -> Result<Vec<u8>, VMError> {
+    let mut data = vec![0u8; length as usize];
+    for (i, c) in data.iter_mut().enumerate() {
+        *c = machine
+            .memory_mut()
+            .load8(&Mac::REG::from_u64(address).overflowing_add(&Mac::REG::from_u64(i as u64)))?
+            .to_u8();
+    }
+    Ok(data)
 }
 
 fn store_data<Mac: SupportMachine>(
@@ -33,7 +48,7 @@ fn store_data<Mac: SupportMachine>(
 }
 
 impl<'a, H: Hasher + Default, S: Store<H256>, Mac: SupportMachine> Syscalls<Mac>
-    for TreeSyscalls<'a, H, S>
+    for VmSyscalls<'a, H, S>
 {
     fn initialize(&mut self, _machine: &mut Mac) -> Result<(), VMError> {
         Ok(())
@@ -44,16 +59,16 @@ impl<'a, H: Hasher + Default, S: Store<H256>, Mac: SupportMachine> Syscalls<Mac>
         match code {
             3073 => {
                 let key_address = machine.registers()[A0].to_u64();
-                let key = load_data(machine, key_address)?;
+                let key = load_h256(machine, key_address)?;
                 let value_address = machine.registers()[A1].to_u64();
-                let value = load_data(machine, value_address)?;
+                let value = load_h256(machine, value_address)?;
                 self.result.write_values.insert(key, value);
                 machine.set_register(A0, Mac::REG::from_u64(0));
                 Ok(true)
             }
             3074 => {
                 let key_address = machine.registers()[A0].to_u64();
-                let key = load_data(machine, key_address)?;
+                let key = load_h256(machine, key_address)?;
                 let value_address = machine.registers()[A1].to_u64();
                 let value = match self.result.write_values.get(&key) {
                     Some(value) => *value,
@@ -65,6 +80,20 @@ impl<'a, H: Hasher + Default, S: Store<H256>, Mac: SupportMachine> Syscalls<Mac>
                 };
                 store_data(machine, value_address, &value)?;
                 machine.set_register(A0, Mac::REG::from_u64(0));
+                Ok(true)
+            }
+            3075 => {
+                let data_address = machine.registers()[A0].to_u64();
+                let data_length = machine.registers()[A1].to_u32();
+                let data = load_data(machine, data_address, data_length)?;
+                self.result.return_data = data.into();
+                Ok(true)
+            }
+            3076 => {
+                let data_address = machine.registers()[A0].to_u64();
+                let data_length = machine.registers()[A1].to_u32();
+                let data = load_data(machine, data_address, data_length)?;
+                self.result.logs.push(data.into());
                 Ok(true)
             }
             _ => Ok(false),

--- a/crates/layer/src/vm.rs
+++ b/crates/layer/src/vm.rs
@@ -62,7 +62,9 @@ impl<'a, H: Hasher + Default, S: Store<H256>, Mac: SupportMachine> Syscalls<Mac>
                     Some(value) => *value,
                     None => {
                         let tree_value = self.tree.get(&key).map_err(|_| VMError::Unexpected)?;
-                        self.result.read_values.insert(key, tree_value);
+                        if tree_value != H256::default() {
+                            self.result.read_values.insert(key, tree_value);
+                        }
                         tree_value
                     }
                 };


### PR DESCRIPTION
* Update sparse-merkle-tree to 0.3 (fix sparse-merkle-tree bug https://github.com/jjyr/sparse-merkle-tree/commit/ddc815feba4d4391fb6f0790503f497fc0010037)
* Support handle extra syscalls (`RunContext`)