### PR TITLE
Upgrade sparse-merkle-tree to 0.3.1-pre

### DIFF
--- a/crates/layer/Cargo.toml
+++ b/crates/layer/Cargo.toml
@@ -14,7 +14,7 @@ ckb-script = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.35.0-rc1"
 ckb-vm = { version = "0.19.1", features = ["asm"] }
 derive_more = "0.99.2"
 replace_with = "0.1.5"
-sparse-merkle-tree = "0.3"
+sparse-merkle-tree = "0.3.1-pre"
 
 [dev-dependencies]
 hex = "0.4.2"


### PR DESCRIPTION
There is a bug in the previous version that may cause the root value to be poisoned.

jjyr/sparse-merkle-tree@38a56d0